### PR TITLE
feat: added the ability to mock handlers

### DIFF
--- a/src/__tests__/__snapshots__/setupStoryMocks.test.js.snap
+++ b/src/__tests__/__snapshots__/setupStoryMocks.test.js.snap
@@ -12,6 +12,14 @@ Array [
 ]
 `;
 
+exports[`setupStoryMocks helper when handlers is passed into setupTestWiring should be possible to call a waitForFunction for that handler: passed into onResponse 1`] = `
+Array [
+  Object {
+    "response": "mocked-response",
+  },
+]
+`;
+
 exports[`setupStoryMocks helper when loading stories in the storybook environment mocks should behave the same as in tests: initial render 1`] = `mocked-response`;
 
 exports[`setupStoryMocks helper when mapResults is not passed when the entire passed in api is a function the return value of the function should behave like a normal api: initial render 1`] = `result-of-a-func-call`;

--- a/src/setupStoryMocks.js
+++ b/src/setupStoryMocks.js
@@ -1,10 +1,11 @@
+import React from 'react'
 import buildGetStoryProvider from './buildGetStoryProvider'
 import setupTestWiringBase from './setupTestWiring'
 import getSetupDecorator from './getSetupDecorator'
 import getDecoratorWrapper from './getDecoratorWrapper'
 
-const delay = (ms) => {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+const delay = ms => {
+  return new Promise(resolve => setTimeout(resolve, ms))
 }
 
 const setupStoryMocks = (options = {}) => {
@@ -14,7 +15,7 @@ const setupStoryMocks = (options = {}) => {
     const {
       onMockValueReturned = () => {},
       onMocksCreated = () => {},
-      mapResults = (results) => results,
+      mapResults = results => results,
     } = options
     const mockedFunctions =
       typeof mockedFunctionsBase === 'function'
@@ -23,8 +24,8 @@ const setupStoryMocks = (options = {}) => {
     const delayAmount = mockedFunctions.DELAY_AMOUNT
     onMocksCreated()
     Object.keys(mockedFunctions)
-      .filter((funcName) => funcName !== 'DELAY_AMOUNT')
-      .forEach((funcName) => {
+      .filter(funcName => funcName !== 'DELAY_AMOUNT')
+      .forEach(funcName => {
         currentFunctions[funcName] = async (...args) => {
           const getReturnValue = () => {
             const mockValue = mockedFunctions[funcName]
@@ -66,18 +67,29 @@ const setupStoryMocks = (options = {}) => {
   })
 
   const setupTestWiring = (options = {}) => {
-    const {mappedArgs, storyWrappers} = options
+    const {mappedArgs, storyWrappers, handlers} = options
     return setupTestWiringBase({
       storyWrappers,
       mapResults,
+      handlers,
       api,
       getStoryProvider,
       mappedArgs,
     })
   }
 
+  const createStory = ({props = {}, mocks = {}, Component}) => {
+    const Story = testProps => <Component {...props} {...testProps} />
+    Story.story = Story.story || {}
+    Story.story.props = props
+    Story.story.parameters = Story.story.parameters || {}
+    Story.story.parameters.mocks = mocks
+    return Story
+  }
+
   return {
     setupDecorator,
+    createStory,
     setupTestWiring,
     StoryProvider,
   }

--- a/src/setupTestWiring.js
+++ b/src/setupTestWiring.js
@@ -2,71 +2,98 @@ import {wait, render as baseRender} from '@testing-library/react'
 import React from 'react'
 import {getMocksFromStoryContext} from './helpers'
 
-const capitalize = (s) => s.charAt(0).toUpperCase() + s.slice(1)
+const capitalize = s => s.charAt(0).toUpperCase() + s.slice(1)
 
 const setupTestWiring = ({
   storyWrappers = [],
   api,
+  handlers = [],
   getStoryProvider,
   mapResults,
   mappedArgs = {},
 }) => {
   let callStack = {}
+
+  const addArgsToCallStack = (funcName, ...args) => {
+    if (!callStack[funcName]) {
+      callStack[funcName] = []
+    }
+    callStack[funcName].push({
+      args,
+    })
+  }
   const StoryProvider = getStoryProvider(storyWrappers, {
     mapResults,
     onMocksCreated: () => {
       callStack = {}
     },
     onMockValueReturned: (funcName, ...args) => {
-      if (!callStack[funcName]) {
-        callStack[funcName] = []
-      }
-      callStack[funcName].push({
-        args,
-      })
+      addArgsToCallStack(funcName, ...args)
     },
   })
 
-  const wrapRender = (Story) => {
+  const getArgumentsPassedIntoCallback = (callBackName, desiredCall) => {
+    const index = desiredCall - 1
+    if (!callStack[callBackName]) {
+      return undefined
+    }
+    return callStack[callBackName][index].args
+  }
+
+  const waitForCallback = async (callbackName, desiredCall) => {
+    let args
+    await wait(() => {
+      args = getArgumentsPassedIntoCallback(callbackName, desiredCall)
+      if (args === undefined) {
+        throw Error(`${callbackName} was never called ${desiredCall} times`)
+      }
+    })
+    return args
+  }
+
+  const getWaitForFunc = (name, func, processArgs = (...args) => args) => {
+    let count = 1
+    return async () => {
+      const args = await waitForCallback(name, count, func)
+      count++
+      return processArgs(...args)
+    }
+  }
+
+  const getMockHandlers = props => {
+    return handlers.reduce((memo, handlerName) => {
+      return {
+        ...memo,
+        [handlerName]: (...args) => {
+          const returnValue = props[handlerName](...args)
+          if (returnValue instanceof Promise) {
+            return returnValue.then(value => {
+              addArgsToCallStack(handlerName, ...args)
+              return value
+            })
+          }
+          addArgsToCallStack(handlerName, ...args)
+          return returnValue
+        },
+      }
+    }, {})
+  }
+
+  const wrapRender = Story => {
     const context = Story.story || {}
+    const {props} = context
+    const mockHandlers = getMockHandlers(props)
     const mocks = getMocksFromStoryContext(context)
     return baseRender(
       <StoryProvider {...mocks}>
-        <Story />
+        <Story {...mockHandlers} />
       </StoryProvider>,
     )
   }
 
   const getGlobalFunctions = () => {
-    const getArgumentsPassedIntoCallback = (callBackName, desiredCall) => {
-      const index = desiredCall - 1
-      if (!callStack[callBackName]) {
-        return undefined
-      }
-      return callStack[callBackName][index].args
-    }
-
-    const waitForCallback = async (callbackName, desiredCall) => {
-      let args
-      await wait(() => {
-        args = getArgumentsPassedIntoCallback(callbackName, desiredCall)
-        if (args === undefined) {
-          throw Error(`${callbackName} was never called ${desiredCall} times`)
-        }
-      })
-      return args
-    }
-
-    const getWaitForFunc = (name, func, processArgs = (...args) => args) => {
-      let count = 1
-      return async () => {
-        const args = await waitForCallback(name, count, func)
-        count++
-        return processArgs(...args)
-      }
-    }
-
-    const waitForFuncs = Object.keys(api).reduce((memo, funcName) => {
+    const waitForFuncNames = [...Object.keys(api), ...handlers]
+    const waitForFuncs = waitForFuncNames.reduce((memo, funcName) => {
       return {
         ...memo,
         [`waitFor${capitalize(funcName)}`]: getWaitForFunc(


### PR DESCRIPTION
A frequent task when testing components is confirming that
passed in handler props (onClick, onClose, etc) were called correctly
at the right times with the right arguments. This adds the ability
to pass a handlers array to setupTestWiring that will
automatically make it possible to wait for all of the prop names
that correspond to names in handlers.

This also adds a createStory convenience helper
to create stories